### PR TITLE
Dashboard fixes

### DIFF
--- a/src/Apps/LlamaAirforce/Pages/Bribes/Rounds/Components/GraphBribesRound.vue
+++ b/src/Apps/LlamaAirforce/Pages/Bribes/Rounds/Components/GraphBribesRound.vue
@@ -75,6 +75,7 @@ const categories = computed((): string[] => {
     )
     .orderBy((x: Pool) => x.amountDollars, "desc")
     .map((x) => x.pool)
+    .slice(0, 20)
     .value();
 });
 

--- a/src/Apps/LlamaAirforce/Pages/Bribes/Services/AuraService.ts
+++ b/src/Apps/LlamaAirforce/Pages/Bribes/Services/AuraService.ts
@@ -50,8 +50,9 @@ export default class AuraService extends ServiceBase {
 
   constructor(host: string) {
     super(host);
-    this.latestRound = getLatestAuraRound();
-    this.today = Math.floor(Date.now() / 1000);
+    const today = Math.floor(Date.now() / 1000);
+    this.latestRound = getLatestAuraRound(today);
+    this.today = today;
   }
 
   private async fetchIncentivePerVote(): Promise<number> {

--- a/src/Apps/LlamaAirforce/Pages/Bribes/Util/AuraHelper.ts
+++ b/src/Apps/LlamaAirforce/Pages/Bribes/Util/AuraHelper.ts
@@ -5,7 +5,8 @@ export const AuraConstants = {
   LA_API_URL: "https://llama-airforce-api.aura.finance/dollar-per-vlasset",
   START_ROUND: 28,
   START_DATE: 1689019200,
-  BIWEEKLY: 60 * 60 * 24 * 14,
+  BIWEEKLY: 86_400 * 14,
+  OFFSET: 86_400 * (14 - 5), // 5 day vote period within 14
 };
 
 // Helper to merge HH data
@@ -30,9 +31,8 @@ export function getMergeWithHiddenHands(
   };
 }
 
-export function getLatestAuraRound(): number {
-  const { START_DATE, BIWEEKLY, START_ROUND } = AuraConstants;
-  const today = Math.floor(Date.now() / 1000);
-  const len = Math.ceil((today - START_DATE) / BIWEEKLY);
+export function getLatestAuraRound(today: number): number {
+  const { START_DATE, BIWEEKLY, START_ROUND, OFFSET } = AuraConstants;
+  const len = Math.ceil((today - START_DATE - OFFSET) / BIWEEKLY);
   return START_ROUND + len;
 }


### PR DESCRIPTION
- Applies offset to the round number. This should now surface the latest round when it becomes active (5 days before end)
- Applies limit to chart to 20 proposals 