### PR TITLE
Endpoint update

### DIFF
--- a/src/Apps/LlamaAirforce/Pages/Bribes/Services/AuraService.ts
+++ b/src/Apps/LlamaAirforce/Pages/Bribes/Services/AuraService.ts
@@ -57,10 +57,14 @@ export default class AuraService extends ServiceBase {
   }
 
   private async fetchIncentivePerVote(): Promise<number> {
-    return this.fetch<{ result: number }>(
-      `${LA_API_URL}/${Math.floor(this.today)}`
-    )
-      ?.then(({ result }) => result)
+    return this.fetch<{
+      result: {
+        emissionValuePerVote: number;
+        emissionsPerDollarSpent: number;
+        totalEmission: number;
+      };
+    }>(`${LA_API_URL}/${Math.floor(this.today)}`)
+      ?.then(({ result }) => result.emissionValuePerVote)
       .catch(() => 0);
   }
 


### PR DESCRIPTION
Gm gm!

We just updated this endpoint:
https://llama-airforce-api.aura.finance/dollar-per-vlasset/1714482469036

The new response type is:
```TypeScript
{
  error: string | null;
  result: {
    emissionValuePerVote: number; // previous result was only returning that value
    emissionsPerDollarSpent: number;
    totalEmission: number;
  };
}
```
To avoid breaking your app, I made this small PR.